### PR TITLE
fix: always return domain, like \textdomain()

### DIFF
--- a/message-translation-draft.md
+++ b/message-translation-draft.md
@@ -120,11 +120,11 @@ class GettextEmulator
 
     public static function textdomain($text_domain = null)
     {
-        if ($text_domain === null) {
-            return self::$defaultDomain;
+        if ($text_domain !== null) {
+            self::$defaultDomain = $text_domain;
         }
 
-        self::$defaultDomain = $text_domain;
+        return self::$defaultDomain;
     }
 
     public static function gettext($message)


### PR DESCRIPTION
Behave more like built-in function `textdomain()` which always returns the current domain, after possibly changing it.